### PR TITLE
Now compatible with Python 3; automated testing begun

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# OS generated files 
+# OS generated files
 ######################
 .DS_Store
 .DS_Store?
@@ -9,7 +9,7 @@ Icon?
 ehthumbs.db
 Thumbs.db
 
-# R                   
+# R
 #######################
 .Rhistory
 

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,12 @@
-`benchmark` is written and maintained by Jeffrey R. Spies and various 
+`benchmark` is written and maintained by Jeffrey R. Spies and various
 contributors:
 
 Development Lead
 ----------------
 
 - Jeffrey R. Spies <jspies@gmail.com>
+
+Other Contributors
+-------------------
+
+- Jonathan Eunice <jonathan.eunice@gmail.com>  (Python 3 compatibility)

--- a/benchmark/Benchmark.py
+++ b/benchmark/Benchmark.py
@@ -9,59 +9,60 @@ import sys
 from . import statistics
 from . import tables
 
+
 def benchmark_fn(tests, each=5, setup=None, teardown=None, eachsetup=None, eachteardown=None):
     pass
 
 class Benchmark(object):
-    def __init__(self, 
-        
+    def __init__(self,
+
         each=5,
 
-        prefix="test_", 
-        setUp="setUp", 
+        prefix="test_",
+        setUp="setUp",
         tearDown="tearDown",
-        eachSetUp="eachSetUp", 
+        eachSetUp="eachSetUp",
         eachTearDown="eachTearDown",
-        
-        format="markdown", 
-        sort_by="mean", 
-        order=['name', 'rank', 'runs', 'mean', 'sd', 'factor'], 
+
+        format="markdown",
+        sort_by="mean",
+        order=['name', 'rank', 'runs', 'mean', 'sd', 'factor'],
         header=None,
-        cellFormats=None, 
+        cellFormats=None,
         numberFormat = "%.4g",
-        
+
         **kwargs):
-        
+
         self.__set_from_attribute("each", each)
         self.__set_from_attribute("label", self.__class__.__name__.replace('_', ' '))
-        
+
         self.__set_from_attribute("format", format)
         self.__set_from_attribute("sort_by", sort_by)
         self.__set_from_attribute("order", order)
         self.__set_from_attribute("header", header)
         self.__set_from_attribute("cellFormats", cellFormats)
         self.__set_from_attribute("numberFormat", numberFormat)
-        
+
         if sys.platform == "win32":
             self.__timer = time.clock # On Windows, the best timer is time.clock()
         else:
             self.__timer = time.time # On most other platforms the best timer is time.time()
-        
+
         self.__prefix = prefix
         self.__setUp = setUp
         self.__tearDown = tearDown
         self.__eachSetUp = eachSetUp
         self.__eachTearDown = eachTearDown
-        
+
     def __collect_tests(self):
         return [test for test in dir(self) if test.startswith(self.__prefix)]
-    
+
     def __set_from_attribute(self, name, value):
         try:
             getattr(self, name)
         except:
             setattr(self, name, value)
-    
+
     def __run_test(self, name):
         tick = self.__timer()
         tResult = self.__run_fn(name)
@@ -72,28 +73,28 @@ class Benchmark(object):
 
     def __run_fn(self, name):
         return getattr(self, name)()
-    
+
     def __testAndRunFn(self, name):
         if name in dir(self):
             self.__run_fn(name)
 
     def run(self, previousResults=None):
         # TODO Add previous results
-        
+
         self.__testAndRunFn(self.__setUp)
-        
+
         tests = self.__collect_tests()
         testQueue = []
-        
+
         self.results = {}
         for number, testname in enumerate(tests):
             self.results[testname] = {'total':0, 'sumOfSq':0}
             testQueue.extend([number for i in range(0, self.each)])
-        
+
         random.shuffle(testQueue)
-        
+
         dirSelf = dir(self)
-        
+
         # Why the following?  Checks to see if eachSetUp and eachTearDown
         # functions would have to be done "each" number of times; this
         # checks once, and then, if there, runs them accordingly.
@@ -113,7 +114,7 @@ class Benchmark(object):
         else:
             for testId in testQueue:
                 self.__run_test(tests[testId])
-        
+
         self.table = []
 
         for key in self.results.keys():
@@ -128,38 +129,38 @@ class Benchmark(object):
                 row['sd'] = row['var']**.5
             else:
                 row['var'] = 'NA'
-                row['sd'] = 'NA'            
+                row['sd'] = 'NA'
             self.table.append(row)
-        
+
         self.table = sorted(self.table, key=operator.itemgetter('mean'))
         for i, v in enumerate(self.table):
             v['rank'] = i+1
             v['factor'] = str(float(v['mean'])/float(self.table[0]['mean']))
             if row['runs'] > 1:
                 v['pvalue'] = statistics.tTest(
-                    v['mean'], v['sd'], v['runs'], 
+                    v['mean'], v['sd'], v['runs'],
                     self.table[0]['mean'], self.table[0]['sd'], self.table[0]['runs'],
                     unequalVariance=True)[2] if i > 0 else 'NA'
             else:
                 v['pvalue'] = 'NA'
-        
+
         self.__testAndRunFn(self.__tearDown)
-    
+
     def get_total_runs(self):
         return self.each*len(self.table)
-    
+
     def get_table(self, format=None, sort_by=None, order=None, header=None,
         cellFormats=None, numberFormat = None, **kwargs):
-        
+
         format = format if format else self.format
         sort_by = sort_by if sort_by else self.sort_by
         order = order if order else self.order
         header = header if header else self.header
         cellFormats = cellFormats if cellFormats else self.cellFormats
         numberFormat = numberFormat if numberFormat else self.numberFormat
-        
+
         self.table = sorted(self.table, key=operator.itemgetter(sort_by))
-        
+
         header = header if header else order
 
         reduced_table = []
@@ -182,7 +183,7 @@ class Benchmark(object):
                 value = str(value)
                 row.append(value)
             reduced_table.append(row)
-        
+
         if format.lower() in ['markdown', 'md']:
             return tables.as_markdown(header, reduced_table)
         elif format.lower() in ['csv', 'comma']:

--- a/benchmark/__init__.py
+++ b/benchmark/__init__.py
@@ -2,10 +2,10 @@ __author__ = "Jeffrey R. Spies"
 __copyright__ = "Copyright 2012 Jeffrey R. Spies"
 __credits__ = ["Jeffrey R. Spies"]
 __license__ = "Apache License, Version 2.0"
-__VERSION__ = '0.1.6'
+__VERSION__ = '0.2.0'
 __maintainer__ = "Jeffrey R. Spies"
 __email__ = "jspies@gmail.com"
 __status__ = "Beta"
 
-from main import BenchmarkProgram, main
-from Benchmark import Benchmark
+from benchmark.main import BenchmarkProgram, main
+from benchmark.Benchmark import Benchmark

--- a/benchmark/main.py
+++ b/benchmark/main.py
@@ -10,14 +10,19 @@ import platform
 import os
 import sys
 
+_PY3 = sys.version_info[0] == 3
+
+if _PY3:
+    basestring = str
+
 class BenchmarkProgram(object):
-    
+
     def __init__(self, module="__main__", **kwargs):
         if isinstance(module, basestring):
             self.module = __import__(module)
-        
+
         benchmarks = self.loadFromModule(self.module)
-        
+
         totalRuns = 0
         objects = []
         for obj in benchmarks:
@@ -25,21 +30,21 @@ class BenchmarkProgram(object):
             obj.run()
             objects.append(obj)
             totalRuns += obj.get_total_runs()
-        
+
         title = 'Benchmark Report'
         info = 'Each of the above %s runs were run in random, non-consecutive order by' % str(totalRuns)
         info += os.linesep
         info += '`benchmark` v' + __VERSION__ + ' (http://jspi.es/benchmark) with Python ' + platform.python_version()
         info += os.linesep
         info += '%s-%s-%s on %s' % (
-            platform.system(), 
-            platform.release(), 
-            platform.machine(), 
+            platform.system(),
+            platform.release(),
+            platform.machine(),
             time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime())
         ) + '.'
-        
+
         sys.stdout.write(self.printMarkdown(objects, title, info, **kwargs))
-    
+
     def printMarkdown(self, benchmarks, title, info, **kwargs):
         lines = ''
 
@@ -47,7 +52,7 @@ class BenchmarkProgram(object):
         lines += title
         lines += os.linesep + '='*len(title)
         lines += os.linesep*2
-        
+
         for obj in benchmarks:
             title = obj.label
             labelLength = len(title) if len(title) > 5 else 5
@@ -55,15 +60,15 @@ class BenchmarkProgram(object):
             lines += os.linesep
             lines += '-'*labelLength
             lines += os.linesep*2
-            
+
             lines += obj.get_table(**kwargs)
             lines += os.linesep*2
-        
+
         lines += info
         lines += os.linesep*2
 
         return lines
-        
+
     def loadFromModule(self, module):
         benchmarks = []
         for name in dir(module):

--- a/benchmark/tables.py
+++ b/benchmark/tables.py
@@ -14,20 +14,20 @@ def get_column_widths(header, table):
 def as_markdown(header, table):
     maxSize = get_column_widths(header, table)
     lines = []
-    lines.append(' | '.join([string.rjust(v, maxSize[i]) for i, v in enumerate(header)]))
+    lines.append(' | '.join([v.rjust(maxSize[i]) for i, v in enumerate(header)]))
     lines.append('-|-'.join(['-'*size for size in maxSize]))
     for row in table:
-        lines.append(' | '.join([string.rjust(v, maxSize[i]) for i, v in enumerate(row)]))
+        lines.append(' | '.join([v.rjust(maxSize[i]) for i, v in enumerate(row)]))
     return os.linesep.join(lines)
-    
+
 def as_rst(header, table):
     maxSize = get_column_widths(header, table)
     lines = []
     lines.append('+-' + '-+-'.join(['-'*size for size in maxSize]) + '-+')
-    lines.append('| ' + ' | '.join([string.rjust(v, maxSize[i]) for i, v in enumerate(header)]) + ' |')
+    lines.append('| ' + ' | '.join([v.rjust(maxSize[i]) for i, v in enumerate(header)]) + ' |')
     lines.append('+=' + '=+='.join(['='*size for size in maxSize]) + '=+')
     for row in table:
-        lines.append('| ' + ' | '.join([string.rjust(v, maxSize[i]) for i, v in enumerate(row)]) + ' |')
+        lines.append('| ' + ' | '.join([v.rjust(maxSize[i]) for i, v in enumerate(row)]) + ' |')
         lines.append('+-' + '-+-'.join(['-'*size for size in maxSize]) + '-+')
     return os.linesep.join(lines)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+python_files = test/*.py

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@ setup(
     description='Python benchmarker / benchmarking framework',
     long_description=open('README.txt').read(),
     packages=['benchmark'],
+    install_requires=[],
+    tests_require = ['tox', 'pytest', 'six>=1.8'],
     include_package_data=True,
     zip_safe=False,
     platforms='any',
@@ -25,5 +27,14 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Software Development :: Testing",
         "Topic :: System :: Benchmark",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2.6",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.2",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy"
     ]
 )

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -8,12 +8,12 @@ _PY3 = sys.version_info[0] == 3
 _PYPY = platform.python_implementation() == 'PyPy'
 
 
-def test_example():
+def test_install():
     """
-    Test the ecample provided in the documentation.
-    Shows that the module installs well, and it
-    basically runs. More an integration test than
-    a unit test, but whatev!
+    Test the ecample provided in the documentation. Shows that the module
+    installs well. Not yet intended to show proper operation--just that it
+    properly installs and imports, esp. on Python 3 where previous versions have
+    not run. More an integration test than a unit test, but whatev!
     """
 
     import math

--- a/test/test_show.py
+++ b/test/test_show.py
@@ -1,0 +1,55 @@
+
+import pytest
+import benchmark
+import sys
+import platform
+
+_PY3 = sys.version_info[0] == 3
+_PYPY = platform.python_implementation() == 'PyPy'
+
+
+def test_example():
+    """
+    Test the ecample provided in the documentation.
+    Shows that the module installs well, and it
+    basically runs. More an integration test than
+    a unit test, but whatev!
+    """
+
+    import math
+
+    class Benchmark_Sqrt(benchmark.Benchmark):
+
+        each = 4 # scaled for fast operation
+
+        def setUp(self):
+            # Only using setUp in order to subclass later
+            # Can also specify tearDown, eachSetUp, and eachTearDown
+            self.size = 20
+
+        def test_pow_operator(self):
+            for i in xrange(self.size):
+                z = i**.5
+
+        def test_pow_function(self):
+            for i in xrange(self.size):
+                z = pow(i, .5)
+
+        def test_sqrt_function(self):
+            for i in xrange(self.size):
+                z = math.sqrt(i)
+
+    class Benchmark_Sqrt2(Benchmark_Sqrt):
+        # Subclass the previous benchmark to change input using
+        # self.setUp()
+
+        label = "Benchmark Sqrt on a larger range"
+        # The above label comes from the class name, this oen
+        # comes from the label attribute
+
+        each = 9
+
+        def setUp(self):
+            self.size = 75
+
+    benchmark.main(format="markdown", numberFormat="%.4g")

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py26, py27, py32, py33, py34, pypy
+
+[testenv]
+changedir=test
+deps=
+    pytest
+commands=py.test {posargs}


### PR DESCRIPTION
Apologize for the large number of apparent changes. My editor trims whitespace at the end of line (for PEP-8) compatibility. I didn't realize the original copy did not use that convention until I saw how many lines are in the pull request. 
