### PR TITLE
clarify statistics.py license

### DIFF
--- a/benchmark/statistics.py
+++ b/benchmark/statistics.py
@@ -1,5 +1,5 @@
 """
-These functions are mostly:
+These functions are used under the Lesser General Public Licence version 3 from:
 
 Copyright (c) Maurice H.T. Ling <mauriceling@acm.org>
 @see: Ling, MHT. 2009. Compendium of Distributions, I: Beta, Binomial, Chi-


### PR DESCRIPTION
attempt at fixing #5, taking actual license information from http://ojs.pythonpapers.org/index.php/tppsc/article/view/84/84
